### PR TITLE
1.1.0 - Add operation visitors to transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,3 +259,32 @@ And if there have been previous rollbacks, the following is appended:
 Previous rollbacks:
 {previousRollbacks}
 ```
+
+# Visiting operations
+
+The default implementation of `Transaction` implements the interface
+`\Johmanx10\Transaction\Visitor\AcceptingTransactionInterface`, allowing it to
+accept operation visitors, implementing
+`\Johmanx10\Transaction\Visitor\OperationVisitorInterface`.
+
+This can be used to gather information about operations that are executed during
+a transaction commit.
+
+The following shows how to log every operation that is about to be executed
+within the transaction:
+
+```php
+<?php
+use Johmanx10\Transaction\OperationInterface;
+use Johmanx10\Transaction\Transaction;
+use Johmanx10\Transaction\Visitor\LogOperationVisitor;
+use Psr\Log\LoggerInterface;
+
+/** @var LoggerInterface $logger */
+$visitor = new LogOperationVisitor($logger);
+
+/** @var OperationInterface[] $operations */
+$transaction = new Transaction(...$operations);
+
+$transaction->commit($visitor);
+```

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,11 @@
         "ext-SPL": "^7.2"
     },
     "require-dev": {
-        "mediact/testing-suite": "@stable"
+        "mediact/testing-suite": "@stable",
+        "psr/log": "^1.0"
+    },
+    "suggest": {
+        "psr/log": "To log operations."
     },
     "autoload": {
         "psr-4": {

--- a/src/Visitor/AcceptingTransactionInterface.php
+++ b/src/Visitor/AcceptingTransactionInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Johmanx10\Transaction\Visitor;
+
+use Johmanx10\Transaction\Exception\TransactionRolledBackExceptionInterface;
+use Johmanx10\Transaction\TransactionInterface;
+
+interface AcceptingTransactionInterface extends TransactionInterface
+{
+    /**
+     * Commit the operations in the transaction.
+     * Roll back operations in reverse order, from the point where a throwable
+     * was caught.
+     *
+     * @param OperationVisitorInterface ...$visitors
+     *
+     * @return void
+     *
+     * @throws TransactionRolledBackExceptionInterface When the transaction was
+     *   rolled back.
+     */
+    public function commit(OperationVisitorInterface ...$visitors): void;
+}

--- a/src/Visitor/LogOperationVisitor.php
+++ b/src/Visitor/LogOperationVisitor.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Johmanx10\Transaction\Visitor;
+
+use Johmanx10\Transaction\Formatter\OperationFormatter;
+use Johmanx10\Transaction\Formatter\OperationFormatterInterface;
+use Johmanx10\Transaction\OperationInterface;
+use Psr\Log\LoggerInterface;
+
+class LogOperationVisitor implements OperationVisitorInterface
+{
+    /** @var LoggerInterface */
+    private $logger;
+
+    /** @var OperationFormatterInterface */
+    private $formatter;
+
+    /**
+     * Constructor.
+     *
+     * @param LoggerInterface             $logger
+     * @param OperationFormatterInterface $formatter
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        OperationFormatterInterface $formatter = null
+    ) {
+        $this->logger    = $logger;
+        $this->formatter = $formatter ?? new OperationFormatter();
+    }
+
+    /**
+     * Visit the given operation.
+     *
+     * @param OperationInterface $operation
+     *
+     * @return void
+     */
+    public function __invoke(OperationInterface $operation): void
+    {
+        $this->logger->info(
+            $this->formatter->format($operation)
+        );
+    }
+}

--- a/src/Visitor/LogOperationVisitor.php
+++ b/src/Visitor/LogOperationVisitor.php
@@ -10,6 +10,7 @@ use Johmanx10\Transaction\Formatter\OperationFormatter;
 use Johmanx10\Transaction\Formatter\OperationFormatterInterface;
 use Johmanx10\Transaction\OperationInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 class LogOperationVisitor implements OperationVisitorInterface
 {
@@ -19,18 +20,24 @@ class LogOperationVisitor implements OperationVisitorInterface
     /** @var OperationFormatterInterface */
     private $formatter;
 
+    /** @var string */
+    private $logLevel;
+
     /**
      * Constructor.
      *
      * @param LoggerInterface             $logger
      * @param OperationFormatterInterface $formatter
+     * @param string                      $logLevel
      */
     public function __construct(
         LoggerInterface $logger,
-        OperationFormatterInterface $formatter = null
+        OperationFormatterInterface $formatter = null,
+        string $logLevel = LogLevel::INFO
     ) {
         $this->logger    = $logger;
         $this->formatter = $formatter ?? new OperationFormatter();
+        $this->logLevel  = $logLevel;
     }
 
     /**
@@ -42,7 +49,8 @@ class LogOperationVisitor implements OperationVisitorInterface
      */
     public function __invoke(OperationInterface $operation): void
     {
-        $this->logger->info(
+        $this->logger->log(
+            $this->logLevel,
             $this->formatter->format($operation)
         );
     }

--- a/src/Visitor/OperationVisitorInterface.php
+++ b/src/Visitor/OperationVisitorInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Johmanx10\Transaction\Visitor;
+
+use Johmanx10\Transaction\OperationInterface;
+
+interface OperationVisitorInterface
+{
+    /**
+     * Visit the given operation.
+     *
+     * @param OperationInterface $operation
+     *
+     * @return void
+     */
+    public function __invoke(OperationInterface $operation): void;
+}

--- a/tests/Functional/Visitor/LoggingTransactionTest.php
+++ b/tests/Functional/Visitor/LoggingTransactionTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Johmanx10\Transaction\Tests\Functional\Visitor;
+
+use Johmanx10\Transaction\Operation;
+use Johmanx10\Transaction\Transaction;
+use Johmanx10\Transaction\Visitor\LogOperationVisitor;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\Test\TestLogger;
+
+class LoggingTransactionTest extends TestCase
+{
+    /**
+     * @return void
+     * @coversNothing
+     */
+    public function testLogVisitorLogsOperationsInTransaction(): void
+    {
+        $logger      = new TestLogger();
+        $visitor     = new LogOperationVisitor($logger);
+        $description = 'Performing operation within ' . __METHOD__;
+        $transaction = new Transaction(
+            new Operation(
+                function () {
+                },
+                function () {
+                },
+                $description
+            )
+        );
+
+        $transaction->commit($visitor);
+
+        $this->assertTrue(
+            $logger->hasInfo($description),
+            'The logger receives a description of the operation to be executed.'
+        );
+    }
+}

--- a/tests/Functional/Visitor/LoggingTransactionTest.php
+++ b/tests/Functional/Visitor/LoggingTransactionTest.php
@@ -10,6 +10,7 @@ use Johmanx10\Transaction\Operation;
 use Johmanx10\Transaction\Transaction;
 use Johmanx10\Transaction\Visitor\LogOperationVisitor;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
 use Psr\Log\Test\TestLogger;
 
 class LoggingTransactionTest extends TestCase
@@ -21,7 +22,7 @@ class LoggingTransactionTest extends TestCase
     public function testLogVisitorLogsOperationsInTransaction(): void
     {
         $logger      = new TestLogger();
-        $visitor     = new LogOperationVisitor($logger);
+        $visitor     = new LogOperationVisitor($logger, null, LogLevel::EMERGENCY);
         $description = 'Performing operation within ' . __METHOD__;
         $transaction = new Transaction(
             new Operation(
@@ -36,7 +37,7 @@ class LoggingTransactionTest extends TestCase
         $transaction->commit($visitor);
 
         $this->assertTrue(
-            $logger->hasInfo($description),
+            $logger->hasRecord($description, LogLevel::EMERGENCY),
             'The logger receives a description of the operation to be executed.'
         );
     }

--- a/tests/LogOperationVisitorTest.php
+++ b/tests/LogOperationVisitorTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Johmanx10\Transaction\Tests;
+
+use Johmanx10\Transaction\Formatter\OperationFormatterInterface;
+use Johmanx10\Transaction\OperationInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Johmanx10\Transaction\Visitor\LogOperationVisitor;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \Johmanx10\Transaction\Visitor\LogOperationVisitor
+ */
+class LogOperationVisitorTest extends TestCase
+{
+    /**
+     * @return void
+     *
+     * @covers ::__construct
+     */
+    public function testConstructor(): void
+    {
+        $this->assertInstanceOf(
+            LogOperationVisitor::class,
+            new LogOperationVisitor(
+                $this->createMock(LoggerInterface::class)
+            )
+        );
+
+        $this->assertInstanceOf(
+            LogOperationVisitor::class,
+            new LogOperationVisitor(
+                $this->createMock(LoggerInterface::class),
+                $this->createMock(OperationFormatterInterface::class)
+            )
+        );
+    }
+
+    /**
+     * @return void
+     *
+     * @covers ::__invoke
+     */
+    public function testInvoke(): void
+    {
+        /** @var LoggerInterface|MockObject $logger */
+        $logger = $this->createMock(LoggerInterface::class);
+
+        /** @var OperationFormatterInterface|MockObject $formatter */
+        $formatter = $this->createMock(OperationFormatterInterface::class);
+
+        $subject = new LogOperationVisitor($logger, $formatter);
+
+        $logger
+            ->expects(self::once())
+            ->method('info')
+            ->with('Operation foo');
+
+        $formatter
+            ->expects(self::once())
+            ->method('format')
+            ->with(self::isInstanceOf(OperationInterface::class))
+            ->willReturn('Operation foo');
+
+        $subject->__invoke($this->createMock(OperationInterface::class));
+    }
+}

--- a/tests/Visitor/LogOperationVisitorTest.php
+++ b/tests/Visitor/LogOperationVisitorTest.php
@@ -4,7 +4,7 @@
  * https://www.mediact.nl
  */
 
-namespace Johmanx10\Transaction\Tests;
+namespace Johmanx10\Transaction\Tests\Visitor;
 
 use Johmanx10\Transaction\Formatter\OperationFormatterInterface;
 use Johmanx10\Transaction\OperationInterface;
@@ -12,6 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Johmanx10\Transaction\Visitor\LogOperationVisitor;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  * @coversDefaultClass \Johmanx10\Transaction\Visitor\LogOperationVisitor
@@ -39,6 +40,15 @@ class LogOperationVisitorTest extends TestCase
                 $this->createMock(OperationFormatterInterface::class)
             )
         );
+
+        $this->assertInstanceOf(
+            LogOperationVisitor::class,
+            new LogOperationVisitor(
+                $this->createMock(LoggerInterface::class),
+                $this->createMock(OperationFormatterInterface::class),
+                LogLevel::DEBUG
+            )
+        );
     }
 
     /**
@@ -54,12 +64,12 @@ class LogOperationVisitorTest extends TestCase
         /** @var OperationFormatterInterface|MockObject $formatter */
         $formatter = $this->createMock(OperationFormatterInterface::class);
 
-        $subject = new LogOperationVisitor($logger, $formatter);
+        $subject = new LogOperationVisitor($logger, $formatter, LogLevel::ALERT);
 
         $logger
             ->expects(self::once())
-            ->method('info')
-            ->with('Operation foo');
+            ->method('log')
+            ->with(LogLevel::ALERT, 'Operation foo');
 
         $formatter
             ->expects(self::once())


### PR DESCRIPTION
This introduces the concept of operation visitors. Operation visitors
can be passed in the `commit` call on a transaction, to visit every
operation just before it is invoked by the transaction.